### PR TITLE
Add higher contrast error color

### DIFF
--- a/src/netlify_eventobserver.ts
+++ b/src/netlify_eventobserver.ts
@@ -60,7 +60,7 @@ netlifyEvents.on('enqueued', ({ branch, context }) => {
 });
 
 netlifyEvents.on('error', ({ branch, context }) => {
-  logOutputMessage(`Failed to deploy vscode.ThemeColor${branch} to ${context}`);
+  logOutputMessage(`Failed to deploy ${branch} to ${context}`);
 
   buildStatus.text = `$(issue-opened)  Netlify Build Status: ${branch} failed to deploy to ${context}!`;
   buildStatus.color = errorTextColor;

--- a/src/netlify_eventobserver.ts
+++ b/src/netlify_eventobserver.ts
@@ -3,6 +3,8 @@ import { format } from 'date-fns';
 import { siteId, apiToken, setInterval } from './config';
 import { netlifyEvents } from './netlify_eventemitter';
 
+const errorTextColor = '#ffbc00';
+
 const buildStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -200);
 const output = vscode.window.createOutputChannel('Netlify');
 
@@ -61,7 +63,7 @@ netlifyEvents.on('error', ({ branch, context }) => {
   logOutputMessage(`Failed to deploy vscode.ThemeColor${branch} to ${context}`);
 
   buildStatus.text = `$(issue-opened)  Netlify Build Status: ${branch} failed to deploy to ${context}!`;
-  buildStatus.color = 'red';
+  buildStatus.color = errorTextColor;
   buildStatus.show();
 });
 
@@ -69,6 +71,6 @@ netlifyEvents.on('fetching-deploy-error', () => {
   logOutputMessage(`Failed to fetch deploy status. Stopping polling on Netlify Deploys API.`);
 
   buildStatus.text = `$(issue-opened)  Netlify Build Status: Failed to fetch deploy status`;
-  buildStatus.color = 'red';
+  buildStatus.color = errorTextColor;
   buildStatus.show();
 });


### PR DESCRIPTION
# Proposed Changes

This PR aims to improve the readability of the error messages that appear in the status bar.

I have changed the text color to [#FFBC00](https://www.colorhexa.com/ffbc00) which is subtle but still has decent contrast with the blue background.

This PR resolves issue https://github.com/ShailenNaidoo/Netlify/issues/6

I tested it by replacing the listening message color as I wasn't able to replicate an error message state.

<img width="459" alt="Screen Shot 2019-12-19 at 4 41 31 pm" src="https://user-images.githubusercontent.com/18509578/71145535-7b6a2900-227e-11ea-86a8-8fa7136fe14a.png">

FWIW I used this tool to help me find a color: https://paletton.com/#uid=33v0u0k++JguxZLP++V+WtF+9ng