### PR TITLE
Ask for only latest deploy

### DIFF
--- a/src/netlify_eventemitter.ts
+++ b/src/netlify_eventemitter.ts
@@ -12,6 +12,7 @@ const netlifyEvents = new EventEmitter();
 
 const getNetlifyBuildStatus = async (ctx: Context) => {
   const { data } = await axios.get(`https://api.netlify.com/api/v1/sites/${ctx.siteId}/deploys`, {
+    params: { per_page: 1 },
     headers: ctx.apiToken ? { 'Authorization': `Bearer ${ctx.apiToken}` } : {}
   });
 


### PR DESCRIPTION
Since the extension is only displaying information for one deploy, there's no need to ask for more than one in the `/deploys` endpoint. The Netlify API supports [pagination parameters](https://docs.netlify.com/api/get-started/#pagination) that we can leverage in this extension. This will make the requests much much faster since there's less data to process and transfer.

You can look at a similar change done in another extension, with great results: https://blog.jim-nielsen.com/2019/how-to-create-a-macos-menu-bar-app-for-netlify/